### PR TITLE
Refactored the way automatic updates are configured

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -10,18 +10,24 @@ win_patch_categories:
 # Skip optional Windows updates
 win_patch_skip_optional: true
 
-# Disable automatic Windows updates (in a non AD environment)
-win_patch_disable_automatic: true
+# Set Windows update registry options (in a non AD environment) - by default disables all automatic updates
+# https://learn.microsoft.com/de-de/security-updates/windowsupdateservices/18127499
+# A third key of state can be provided for each element in the list, defaults to present
+win_patch_registry_options:
+  - name: NoAutoUpdate
+    value: 1
+  - name: AutoInstallMinorUpdates
+    value: 0
+    # state: present/absent
 
 # Check if there is a reboot pending and reboot BEFORE starting updates
 win_patch_reboot_before_if_required: true
 
 # Reboot timeout in seconds (time to wait for the node to be available again)
-win_patch_reboot_timeout: 1800
+win_patch_reboot_timeout: 3600
 
 # PowerShell commad determine if the machine is ready after reboot (expects success)
 win_patch_reboot_test_command: exit (Get-Service -Name WinRM).Status -ne "Running"
-
 # (Optional) A list of update titles or KB numbers used to specify which updates are to be excluded
 # win_patch_reject_list: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,5 +1,5 @@
 ---
-- name: Disable automatic Windows updates
+- name: Set Automatic Windows update options
   ansible.windows.win_regedit:
     path: HKLM:\Software\Policies\Microsoft\Windows\WindowsUpdate\AU
     name: "{{ item.name }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -69,8 +69,7 @@
             category_names: "{{ win_patch_categories }}"
             state: installed
             skip_optional: "{{ win_patch_skip_optional }}"
-            reboot: true
-            reboot_timeout: "{{ win_patch_reboot_timeout }}"
+            reboot: false
             reject_list: "{{ win_patch_reject_list | default([], true) }}"
             log_path: "{{ win_patch_log_path | default(omit) }}"
           register: win_updates_result
@@ -85,8 +84,7 @@
             category_names: "{{ win_patch_categories }}"
             state: installed
             skip_optional: "{{ win_patch_skip_optional }}"
-            reboot: true
-            reboot_timeout: "{{ win_patch_reboot_timeout }}"
+            reboot: false
             reject_list: "{{ win_patch_reject_list | default([], true) }}"
             log_path: "{{ win_patch_log_path | default(omit) }}"
           register: win_updates_result

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,18 +4,13 @@
     path: HKLM:\Software\Policies\Microsoft\Windows\WindowsUpdate\AU
     name: "{{ item.name }}"
     data: "{{ item.value }}"
+    state: "{{ item.state | default('present', true) }}"
     type: dword
-  loop:
-    - name: NoAutoUpdate
-      value: 1
-    - name: AutoInstallMinorUpdates
-      value: 0
+  loop: "{{ win_patch_registry_options }}"
   notify: Restart Windows update service
-  when: win_patch_disable_automatic | bool
 
 - name: Flush handlers
   ansible.builtin.meta: flush_handlers
-  when: win_patch_disable_automatic | bool
 
 - name: Check for pending Windows updates
   ansible.windows.win_updates:
@@ -74,7 +69,8 @@
             category_names: "{{ win_patch_categories }}"
             state: installed
             skip_optional: "{{ win_patch_skip_optional }}"
-            reboot: false
+            reboot: true
+            reboot_timeout: "{{ win_patch_reboot_timeout }}"
             reject_list: "{{ win_patch_reject_list | default([], true) }}"
             log_path: "{{ win_patch_log_path | default(omit) }}"
           register: win_updates_result
@@ -89,7 +85,8 @@
             category_names: "{{ win_patch_categories }}"
             state: installed
             skip_optional: "{{ win_patch_skip_optional }}"
-            reboot: false
+            reboot: true
+            reboot_timeout: "{{ win_patch_reboot_timeout }}"
             reject_list: "{{ win_patch_reject_list | default([], true) }}"
             log_path: "{{ win_patch_log_path | default(omit) }}"
           register: win_updates_result


### PR DESCRIPTION
# Pull Request Description
- Removed _win_patch_disable_automatic_ variable
- Added _win_patch_registry_options_ which lets you pass registry keys and values related to Automatic Windows update, can be also used to delete registry values
- Breaking since variable and its default were deleted
- Bumped default value of _win_patch_reboot_timeout_ to 3600 seconds

## Change type

- [ ] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [x] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)

## How was this tested?
Tested on Windows 2019, 2022 in test and production environments
