### PR TITLE
Fix win_patch_registry_options variable looping

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,7 +3,7 @@
   ansible.windows.win_regedit:
     path: HKLM:\Software\Policies\Microsoft\Windows\WindowsUpdate\AU
     name: "{{ item.name }}"
-    data: "{{ item.value }}"
+    data: "{{ item.value | default(omit, true) }}"
     state: "{{ item.state | default('present', true) }}"
     type: dword
   loop: "{{ win_patch_registry_options }}"


### PR DESCRIPTION
# Pull Request Description
- Added omiting of value for _win_patch_registry_options_ so that when `state: absent` is used, there is no need to pass in a value

For example:
```
win_patch_registry_options:
  - name: AUOptions
    value: 3
  - name: DetectionFrequencyEnabled
    value: 0
  - name: NoAutoUpdate
    state: absent
```
## Change type

- [x] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)
