### PR TITLE
Add post reboot delay

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,8 +28,13 @@ win_patch_reboot_timeout: 3600
 
 # PowerShell commad determine if the machine is ready after reboot (expects success)
 win_patch_reboot_test_command: exit (Get-Service -Name WinRM).Status -ne "Running"
+
+# Seconds to wait after the reboot command was successful - wait for the system to settle
+win_patch_post_reboot_delay: 60
+
 # (Optional) A list of update titles or KB numbers used to specify which updates are to be excluded
 # win_patch_reject_list: []
 
 # (Optional) Append update progress to the specified file. The directory must already exist.
 # win_patch_log_path: ""
+

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,4 +37,3 @@ win_patch_post_reboot_delay: 60
 
 # (Optional) Append update progress to the specified file. The directory must already exist.
 # win_patch_log_path: ""
-

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -93,4 +93,5 @@
       ansible.windows.win_reboot:
         reboot_timeout: "{{ win_patch_reboot_timeout }}"
         test_command: "{{ win_patch_reboot_test_command }}"
+        post_reboot_delay: "{{ win_patch_post_reboot_delay }}"
       when: win_updates_result.reboot_required | bool


### PR DESCRIPTION
# Pull Request Description
Add post reboot delay to wait for system to settle at the end of the role. 

Intermittently the following task after this role fails since all the parts of the system have not settled yet.

## Change type

- [x] Bug fix (non-breaking change which fixes a specific issue)
- [ ] New feature (non-breaking change adding new functionality)
- [ ] Breaking change (fix or feature that potentially causes existing functionality to fail)
- [ ] Change that does not affect Ansible Role code (Github Actions Workflow, Documentation, or similair)